### PR TITLE
Modify the VL53L0X class in order to be compatible with X-NUCLEO-53L0A1

### DIFF
--- a/src/vl53l0x_class.h
+++ b/src/vl53l0x_class.h
@@ -308,7 +308,10 @@ class VL53L0X : public RangeSensor
        MyDevice.comms_type=1; // VL53L0X_COMMS_I2C
        MyDevice.comms_speed_khz=400;
        Device=&MyDevice;
-       pinMode(gpio0, OUTPUT);
+       if(gpio0 >= 0)
+       {
+         pinMode(gpio0, OUTPUT);
+       }
     }
     
    /** Destructor
@@ -326,7 +329,10 @@ class VL53L0X : public RangeSensor
     /* turns on the sensor */
     virtual void VL53L0X_On(void)
     {
-       digitalWrite(gpio0, HIGH);
+       if(gpio0 >= 0)
+       {
+         digitalWrite(gpio0, HIGH);
+       }
        delay(10);
     }
 
@@ -337,7 +343,10 @@ class VL53L0X : public RangeSensor
     /* turns off the sensor */
     virtual void VL53L0X_Off(void)
     {
-       digitalWrite(gpio0, LOW);
+       if(gpio0 >= 0)
+       {
+         digitalWrite(gpio0, LOW);
+       }
        delay(10);
     }
 
@@ -572,7 +581,7 @@ class VL53L0X : public RangeSensor
  *  @{
  */
 
- private:
+ protected:
     /* api.h functions */
     VL53L0X_Error VL53L0X_DataInit(VL53L0X_DEV Dev);
     VL53L0X_Error VL53L0X_GetOffsetCalibrationDataMicroMeter(VL53L0X_DEV Dev, int32_t *pOffsetCalibrationDataMicroMeter);
@@ -798,7 +807,7 @@ class VL53L0X : public RangeSensor
     int RangeMeasPollContinuousMode();
     int RangeMeasIntContinuousMode(void (*fptr)(void));
 
-
+ protected:
     VL53L0X_DeviceInfo_t DeviceInfo;
 
     /* IO Device */


### PR DESCRIPTION
Hi all,
I need this modification in the VL53L0X class in order to derive the class to support the X-NUCLEO-53L0A1. In practice the subclass of X-NUCLEO-53L0A1 needs also of a port expander class in order to manage the gpio0 pin. I prepared another package with the VL53L0X_X_NUCLEO_53L0A1 subclass definition, the gpio expander class and the examples for X-NUCLEO-53L0A1. Finally, I think that the gesture library should be defined outside this package, because it can be used also by VL6180X component.
Best Regards,
Carlo