### PR TITLE
Add UNUSED define for Arduino boards

### DIFF
--- a/src/vl53l0x_class.cpp
+++ b/src/vl53l0x_class.cpp
@@ -47,6 +47,10 @@
 #include "vl53l0x_tuning.h"
 #include "vl53l0x_types.h"
 
+#ifndef UNUSED
+#define UNUSED(x) x
+#endif
+
 
 /****************** define for i2c configuration *******************************/
 


### PR DESCRIPTION
Add UNUSED definition for Arduino boards