### PR TITLE
Remove invalid reference link from keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -9,7 +9,7 @@
 ComponentObject	KEYWORD1
 LightSensor	KEYWORD1
 RangeSensor	KEYWORD1
-VL53L0X	KEYWORD1	VL53L0X
+VL53L0X	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)


### PR DESCRIPTION
The third field of keywords.txt is used to provide Arduino Language/Libraries Reference links, which are accessed from the Arduino IDE by highlighting the keyword and then selecting "Find in Reference" from the Help or right click menu. Adding values to this field that do not match any existing reference pages results in a "Could not open the URL" error.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywordstxt-format